### PR TITLE
Fix deletion condition for empty directories

### DIFF
--- a/src/VirtualFileSystem/index.ts
+++ b/src/VirtualFileSystem/index.ts
@@ -318,7 +318,7 @@ export class VirtualFileSystem {
             )
         );
 
-        if (delFiles) return;
+        if (delFiles && delFiles.length) return;
 
         // 删除空目录
         await new Promise<void>((resolve, reject) =>


### PR DESCRIPTION
## Summary
- correct logic in VFS `empty` method to check for remaining files before removing directory

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'esbuild-wasm' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684158ed0bc0832dae07a5f2c43f4cbb